### PR TITLE
Update install instruction README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If an explorer is broken, it can't see enemy spaceships.
 ```
 python3.11 -m venv venv
 . venv/bin/activate
-pip install -e .[dev]  # to get the dev dependencies
+pip install -e '.[dev]' # to get the dev dependencies
 ```
 
 ### Install git hook


### PR DESCRIPTION
Changed line ```pip3 install -e .[dev]``` to 
``` pip3 install -e '.[dev]' ```

This fix prevents Zsh from interpreting it as a glob pattern.
This fix hasn't been tested on linux system and other shells.